### PR TITLE
Update 0.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ about:
   home: https://github.com/martinblech/xmltodict
   license: MIT
   license_family: MIT
-  license_url: https://github.com/martinblech/xmltodict/blob/v0.13.0/LICENSE
+  license_file: LICENSE
   description: |
     xmltodict is a Python module that makes
     working with XML feel like you are working with JSON.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "xmltodict" %}
-{% set version = "0.12.0" %}
-{% set sha256 = "50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21" %}
+{% set version = "0.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,29 +7,38 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56
 
 build:
-  noarch: python
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
 
 requirements:
   host:
     - pip
     - python
     - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - xmltodict
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/martinblech/xmltodict
   license: MIT
-  license_file: LICENSE
+  license_family: MIT
+  license_url: https://github.com/martinblech/xmltodict/blob/v0.13.0/LICENSE
+  description: |
+    xmltodict is a Python module that makes
+    working with XML feel like you are working with JSON.
+  doc_url: https://github.com/martinblech/xmltodict/blob/master/README.md
   summary: 'Makes working with XML feel like you are working with JSON'
   dev_url: https://github.com/martinblech/xmltodict
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,8 @@ source:
 build:
   number: 0
   script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
-
+  skip: True  # [py<38]
+  
 requirements:
   host:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,9 +11,9 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<38]
-  
+
 requirements:
   host:
     - pip


### PR DESCRIPTION
# ❄️☆Xmltodict 0.13.0 Update ☆❄️
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2569)
[Upstream](https://github.com/martinblech/xmltodict/blob/v0.13.0/setup.py)
[Dependencies ](https://github.com/martinblech/xmltodict/blob/master/setup.py)
# Changes
- Updated version number and `sha256`
- Updated pinnings or dependencies
- Updated `about` section
- `skip: true` for python versions less than 3.8