### PR TITLE
xmltodict 1.0.2 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,25 +1,24 @@
 {% set name = "xmltodict" %}
-{% set version = "0.14.2" %}
+{% set version = "1.0.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 201e7c28bb210e374999d1dde6382923ab0ed1a8a5faeece48ab525b7810a553
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 54306780b7c2175a3967cad1db92f218207e5bc1aba697d887807c0fb68b7649
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  # https://github.com/martinblech/xmltodict/blob/v0.14.2/setup.py#L25
-  skip: True  # [py<36]
+  skip: true  # [py<39]
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
+    - setuptools >=61
     - wheel
   run:
     - python


### PR DESCRIPTION
xmltodict 1.0.2 

**Destination channel:** Defaults

### Links

- [PKG-11556]
- dev_url:        https://github.com/martinblech/xmltodict/tree/v1.0.2
- conda_forge:    https://github.com/conda-forge/xmltodict-feedstock
- pypi:           https://pypi.org/project/xmltodict/1.0.2
- pypi inspector: https://inspector.pypi.io/project/xmltodict/1.0.2

### Explanation of changes:

- new version number


[PKG-11556]: https://anaconda.atlassian.net/browse/PKG-11556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ